### PR TITLE
Add the new TLD .ss

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7059,6 +7059,17 @@ gov.zw
 mil.zw
 org.zw
 
+// ss : https://registry.nic.ss/
+// IANA https://www.iana.org/domains/root/db/ss.html
+// Enquiries <technical@nic.ss>
+// Please note that the 2nd level(.ss) is only used by the registry (e.g nic.ss) not open to the public
+ss
+edu.ss
+com.ss
+net.ss
+biz.ss
+gov.ss
+org.ss
 
 // newGTLDs
 


### PR DESCRIPTION
Description of Organization
<hr>
<a href ="https://www.iana.org/domains/root/db/ss.html">.ss </a>is the designated country code top-level domain (ccTLD) for South Sudan as approved by the ICANN board on 27 January 2019 and added to the DNS root zone on 2 February 2019. 

Reason for PSL Inclusion
<hr>
To have .ss supported by any applications that reference the public list.